### PR TITLE
Rename "imageHash(es)" to "fileHash(es)", and require an array be passed to mint() instead of a single image

### DIFF
--- a/contracts/CodexTitleAccess.sol
+++ b/contracts/CodexTitleAccess.sol
@@ -16,7 +16,7 @@ contract CodexTitleAccess is CodexTitleCore {
     address _to,
     bytes32 _nameHash,
     bytes32 _descriptionHash,
-    bytes32 _imageHash,
+    bytes32[] _fileHashes,
     string _providerId, // TODO: convert to bytes32
     string _providerMetadataId) // TODO: convert to bytes32
     public
@@ -26,7 +26,7 @@ contract CodexTitleAccess is CodexTitleCore {
       _to,
       _nameHash,
       _descriptionHash,
-      _imageHash,
+      _fileHashes,
       _providerId,
       _providerMetadataId
     );
@@ -84,7 +84,7 @@ contract CodexTitleAccess is CodexTitleCore {
     uint256 _tokenId,
     bytes32 _newNameHash,
     bytes32 _newDescriptionHash,
-    bytes32[] _newImageHashes,
+    bytes32[] _newFileHashes,
     string _providerId, // TODO: convert to bytes32?
     string _providerMetadataId // TODO: convert to bytes32?
   )
@@ -94,7 +94,7 @@ contract CodexTitleAccess is CodexTitleCore {
       _tokenId,
       _newNameHash,
       _newDescriptionHash,
-      _newImageHashes,
+      _newFileHashes,
       _providerId,
       _providerMetadataId
     );

--- a/contracts/CodexTitleCore.sol
+++ b/contracts/CodexTitleCore.sol
@@ -38,7 +38,7 @@ contract CodexTitleCore is CodexTitleMetadata, CodexTitleFees {
     address _to,
     bytes32 _nameHash,
     bytes32 _descriptionHash,
-    bytes32 _imageHash,
+    bytes32[] _fileHashes,
     string _providerId, // TODO: convert to bytes32
     string _providerMetadataId) // TODO: convert to bytes32
     public
@@ -55,11 +55,12 @@ contract CodexTitleCore is CodexTitleMetadata, CodexTitleFees {
     // Add a new token to the allTokens array
     super._mint(_to, newTokenId);
 
-    // Add new token data to the newly created token
-    // Note that we aren't using the struct here so we can directly write to the imageHashes dynamic storage array
-    tokenData[newTokenId].nameHash = _nameHash;
-    tokenData[newTokenId].descriptionHash = _descriptionHash;
-    tokenData[newTokenId].imageHashes.push(_imageHash);
+    // Add metadata to the newly created token
+    tokenData[newTokenId] = CodexTitleData({
+      nameHash: _nameHash,
+      descriptionHash: _descriptionHash,
+      fileHashes: _fileHashes
+    });
 
     if (bytes(_providerId).length != 0 && bytes(_providerMetadataId).length != 0) {
       emit Minted(newTokenId, _providerId, _providerMetadataId);

--- a/contracts/CodexTitleCore.sol
+++ b/contracts/CodexTitleCore.sol
@@ -56,6 +56,10 @@ contract CodexTitleCore is CodexTitleMetadata, CodexTitleFees {
     super._mint(_to, newTokenId);
 
     // Add metadata to the newly created token
+    //
+    // TODO: evaluate gas costs here, it may be more efficient to push each
+    //  individual file onto the existing fileHashes array for this index
+    //  instead of replacing the array altogether
     tokenData[newTokenId] = CodexTitleData({
       nameHash: _nameHash,
       descriptionHash: _descriptionHash,

--- a/contracts/CodexTitleMetadata.sol
+++ b/contracts/CodexTitleMetadata.sol
@@ -32,14 +32,6 @@ contract CodexTitleMetadata is ERC721Token {
   //  via the tokenURI method
   string public tokenURIPrefix;
 
-  // TODO: Is it necessary to have a separate getter for this?
-  function getImageHashByIndex(uint256 _tokenId, uint256 _index) external view returns (bytes32) {
-    bytes32[] memory imageHashes;
-    (,,imageHashes) = getTokenById(_tokenId);
-
-    return imageHashes[_index];
-  }
-
   /**
    * @dev Updates token metadata hashes to whatever is passed in
    * @param _providerId (optional) An ID that identifies which provider is

--- a/contracts/CodexTitleMetadata.sol
+++ b/contracts/CodexTitleMetadata.sol
@@ -50,7 +50,7 @@ contract CodexTitleMetadata is ERC721Token {
     public onlyOwnerOf(_tokenId)
   {
 
-    require(exists(_tokenId));
+    require(exists(_tokenId), "Codex Title with specified tokenId does not exist");
 
     // nameHash is only overridden if it's not a blank string, since name is a
     //  required value
@@ -98,7 +98,7 @@ contract CodexTitleMetadata is ERC721Token {
     returns (bytes32 nameHash, bytes32 descriptionHash, bytes32[] fileHashes)
   {
 
-    require(exists(_tokenId));
+    require(exists(_tokenId), "Codex Title with specified tokenId does not exist");
 
     return (
       tokenData[_tokenId].nameHash,
@@ -124,7 +124,8 @@ contract CodexTitleMetadata is ERC721Token {
    * @param _tokenId uint256 ID of the token to query
    */
   function tokenURI(uint256 _tokenId) public view returns (string) {
-    require(exists(_tokenId));
+
+    require(exists(_tokenId), "Codex Title with specified tokenId does not exist");
 
     bytes memory prefix = bytes(tokenURIPrefix);
     if (prefix.length == 0) {

--- a/contracts/CodexTitleMetadata.sol
+++ b/contracts/CodexTitleMetadata.sol
@@ -12,7 +12,7 @@ contract CodexTitleMetadata is ERC721Token {
   struct CodexTitleData {
     bytes32 nameHash;
     bytes32 descriptionHash;
-    bytes32[] imageHashes;
+    bytes32[] fileHashes;
   }
 
   event Modified(
@@ -20,7 +20,7 @@ contract CodexTitleMetadata is ERC721Token {
     uint256 _tokenId,
     bytes32 _newNameHash,
     bytes32 _newDescriptionHash,
-    bytes32[] _newImageHashes,
+    bytes32[] _newFileHashes,
     string _providerId, // TODO: convert to bytes32?
     string _providerMetadataId // TODO: convert to bytes32?
   );
@@ -43,7 +43,7 @@ contract CodexTitleMetadata is ERC721Token {
     uint256 _tokenId,
     bytes32 _newNameHash,
     bytes32 _newDescriptionHash,
-    bytes32[] _newImageHashes,
+    bytes32[] _newFileHashes,
     string _providerId, // TODO: convert to bytes32?
     string _providerMetadataId // TODO: convert to bytes32?
   )
@@ -66,14 +66,14 @@ contract CodexTitleMetadata is ERC721Token {
     //  (e.g. you can "remove" a description by setting it to a blank string)
     tokenData[_tokenId].descriptionHash = _newDescriptionHash;
 
-    // imageHashes is only overridden if it has more than one value, since at
-    //  least one image (i.e. mainImage) is required
+    // fileHashes is only overridden if it has more than one value, since at
+    //  least one file (i.e. mainImage) is required
     //
     // NOTE: is this the best way to check for an empty bytes32 array?
     //  would (_newNameHash != "") be better in any way?
     //  see: https://ethereum.stackexchange.com/questions/27227/why-does-require-length-of-bytes32-0-not-work
-    if (_newImageHashes.length > 0 && _newImageHashes[0][0] != 0) {
-      tokenData[_tokenId].imageHashes = _newImageHashes;
+    if (_newFileHashes.length > 0 && _newFileHashes[0][0] != 0) {
+      tokenData[_tokenId].fileHashes = _newFileHashes;
     }
 
     if (bytes(_providerId).length != 0 && bytes(_providerMetadataId).length != 0) {
@@ -82,7 +82,7 @@ contract CodexTitleMetadata is ERC721Token {
         _tokenId,
         tokenData[_tokenId].nameHash,
         tokenData[_tokenId].descriptionHash,
-        tokenData[_tokenId].imageHashes,
+        tokenData[_tokenId].fileHashes,
         _providerId,
         _providerMetadataId
       );
@@ -95,11 +95,16 @@ contract CodexTitleMetadata is ERC721Token {
    * @return CodexTitleData token data for the given token ID
    */
   function getTokenById(uint256 _tokenId) public view
-    returns (bytes32 nameHash, bytes32 descriptionHash, bytes32[] imageHashes)
+    returns (bytes32 nameHash, bytes32 descriptionHash, bytes32[] fileHashes)
   {
-    CodexTitleData storage codexTitle = tokenData[_tokenId];
 
-    return (codexTitle.nameHash, codexTitle.descriptionHash, codexTitle.imageHashes);
+    require(exists(_tokenId));
+
+    return (
+      tokenData[_tokenId].nameHash,
+      tokenData[_tokenId].descriptionHash,
+      tokenData[_tokenId].fileHashes
+    );
   }
 
   /**

--- a/scripts/mintTokens.js
+++ b/scripts/mintTokens.js
@@ -112,7 +112,7 @@ const mintTokens = async (contract, authTokens, imageRecords) => {
           account,
           web3.sha3(result.name),
           web3.sha3(result.description),
-          web3.sha3('image data'),
+          [result.mainImage.hash], // instead of downloading the file, reading it as binary data, and hashing that - we'll just use the hash created by the API since they should produce the same hash anyway
           '1',
           result.id,
         )

--- a/test/helpers/modifyMetadataHashes.js
+++ b/test/helpers/modifyMetadataHashes.js
@@ -1,14 +1,14 @@
 export default async function modifyMetadataHashes({
 
   newNameHash,
-  newImageHashes,
+  newFileHashes,
   newDescriptionHash,
 
   providerId = '',
   providerMetadataId = '',
 
   expectedNameHash = newNameHash,
-  expectedImageHashes = newImageHashes,
+  expectedFileHashes = newFileHashes,
   expectedDescriptionHash = newDescriptionHash,
 
 }) {
@@ -26,7 +26,7 @@ export default async function modifyMetadataHashes({
     this.tokenId,
     newNameHash,
     newDescriptionHash,
-    newImageHashes,
+    newFileHashes,
     providerId,
     providerMetadataId,
   )
@@ -35,7 +35,7 @@ export default async function modifyMetadataHashes({
 
   tokenData[0].should.be.equal(expectedNameHash)
   tokenData[1].should.be.equal(expectedDescriptionHash)
-  tokenData[2].should.deep.equal(expectedImageHashes)
+  tokenData[2].should.deep.equal(expectedFileHashes)
 
   // no Modified event is emitted when no provider details are specified
   if (!providerId && !providerMetadataId) {
@@ -50,7 +50,7 @@ export default async function modifyMetadataHashes({
   logs[0].args._tokenId.should.be.bignumber.equal(this.tokenId)
   logs[0].args._newNameHash.should.be.equal(tokenData[0])
   logs[0].args._newDescriptionHash.should.be.equal(tokenData[1])
-  logs[0].args._newImageHashes.should.deep.equal(tokenData[2])
+  logs[0].args._newFileHashes.should.deep.equal(tokenData[2])
   logs[0].args._providerId.should.be.equal(providerId)
   logs[0].args._providerMetadataId.should.be.equal(providerMetadataId)
 

--- a/test/token/CodexTitleAccess.test.js
+++ b/test/token/CodexTitleAccess.test.js
@@ -18,13 +18,13 @@ contract('CodexTitleAccess', async function (accounts) {
   const firstTokenMetadata = {
     name: 'First token',
     description: 'This is the first token',
-    imageBytes: 'asdf',
+    files: ['file data'],
   }
 
   const hashedMetadata = {
     name: web3.sha3(firstTokenMetadata.name),
     description: web3.sha3(firstTokenMetadata.description),
-    imageBytes: web3.sha3(firstTokenMetadata.imageBytes),
+    files: firstTokenMetadata.files.map(web3.sha3),
   }
 
   beforeEach(async function () {
@@ -35,7 +35,7 @@ contract('CodexTitleAccess', async function (accounts) {
       creator,
       hashedMetadata.name,
       hashedMetadata.description,
-      hashedMetadata.imageBytes,
+      hashedMetadata.files,
       providerId,
       providerMetadataId,
     )
@@ -54,7 +54,7 @@ contract('CodexTitleAccess', async function (accounts) {
             creator,
             hashedMetadata.name,
             hashedMetadata.description,
-            hashedMetadata.imageBytes,
+            hashedMetadata.files,
             providerId,
             providerMetadataId,
           )
@@ -136,9 +136,9 @@ contract('CodexTitleAccess', async function (accounts) {
         await assertRevert(
           this.token.modifyMetadataHashes(
             firstTokenId,
-            web3.sha3('name'),
-            web3.sha3('description'),
-            [web3.sha3('image')],
+            hashedMetadata.name,
+            hashedMetadata.description,
+            hashedMetadata.files,
             providerId,
             providerMetadataId,
           )

--- a/test/token/CodexTitleProxy.extended.test.js
+++ b/test/token/CodexTitleProxy.extended.test.js
@@ -25,9 +25,9 @@ contract('CodexTitleProxy', async function (accounts) {
       async function mintToken(tokenToMint, tokenCreator) {
         await tokenToMint.mint(
           tokenCreator,
-          'hashedMetadata.name',
-          'hashedMetadata.description',
-          'hashedMetadata.imageBytes',
+          web3.sha3('name'),
+          web3.sha3('description'),
+          [web3.sha3('file data')],
           '1',
           '10'
         )

--- a/test/token/behaviors/CodexTitle.behavior.js
+++ b/test/token/behaviors/CodexTitle.behavior.js
@@ -23,15 +23,13 @@ export default function shouldBehaveLikeCodexTitle(accounts) {
   const firstTokenMetadata = {
     name: 'First token',
     description: 'This is the first token',
-    images: ['asdf'],
+    files: ['file data'],
   }
 
   const hashedMetadata = {
     name: web3.sha3(firstTokenMetadata.name),
     description: web3.sha3(firstTokenMetadata.description),
-    images: firstTokenMetadata.images.map((image) => {
-      return web3.sha3(image)
-    }),
+    files: firstTokenMetadata.files.map(web3.sha3),
   }
 
   describe('like a CodexTitle', function () {
@@ -40,7 +38,7 @@ export default function shouldBehaveLikeCodexTitle(accounts) {
         creator,
         hashedMetadata.name,
         hashedMetadata.description,
-        hashedMetadata.images[0],
+        hashedMetadata.files,
         providerId,
         providerMetadataId
       )
@@ -66,7 +64,7 @@ export default function shouldBehaveLikeCodexTitle(accounts) {
           const tokenData = await this.token.getTokenById(0)
           tokenData[0].should.be.equal(hashedMetadata.name)
           tokenData[1].should.be.equal(hashedMetadata.description)
-          tokenData[2].should.deep.equal(hashedMetadata.images)
+          tokenData[2].should.deep.equal(hashedMetadata.files)
         })
       })
 
@@ -109,7 +107,7 @@ export default function shouldBehaveLikeCodexTitle(accounts) {
               creator,
               hashedMetadata.name,
               hashedMetadata.description,
-              hashedMetadata.images[0],
+              hashedMetadata.files,
               providerId,
               providerMetadataId
             )
@@ -135,7 +133,7 @@ export default function shouldBehaveLikeCodexTitle(accounts) {
                 creator,
                 hashedMetadata.name,
                 hashedMetadata.description,
-                hashedMetadata.images[0],
+                hashedMetadata.files,
                 providerId,
                 providerMetadataId,
               )
@@ -149,7 +147,7 @@ export default function shouldBehaveLikeCodexTitle(accounts) {
 
       const newNameHash = web3.sha3('New name')
       const newDescriptionHash = web3.sha3('New description')
-      const newImageHashes = [web3.sha3('New image 1'), web3.sha3('New image 2')]
+      const newFileHashes = [web3.sha3('new file data 1'), web3.sha3('new file data 2')]
 
       describe('when the sender is not authorized', function () {
         it('should revert', async function () {
@@ -158,7 +156,7 @@ export default function shouldBehaveLikeCodexTitle(accounts) {
               0,
               newNameHash,
               newDescriptionHash,
-              newImageHashes,
+              newFileHashes,
               providerId,
               providerMetadataId,
               { from: unauthorized },
@@ -173,12 +171,12 @@ export default function shouldBehaveLikeCodexTitle(accounts) {
           await modifyMetadataHashes({
             newNameHash,
             newDescriptionHash: hashedMetadata.description,
-            newImageHashes: [],
+            newFileHashes: [],
 
             providerId,
             providerMetadataId,
 
-            expectedImageHashes: hashedMetadata.images,
+            expectedFileHashes: hashedMetadata.files,
           })
         })
 
@@ -186,14 +184,14 @@ export default function shouldBehaveLikeCodexTitle(accounts) {
           await modifyMetadataHashes({
             newNameHash: '',
             newDescriptionHash,
-            newImageHashes: [],
+            newFileHashes: [],
 
             providerId,
             providerMetadataId,
 
             expectedNameHash: hashedMetadata.name,
             expectedDescriptionHash: newDescriptionHash,
-            expectedImageHashes: hashedMetadata.images,
+            expectedFileHashes: hashedMetadata.files,
           })
         })
 
@@ -201,7 +199,7 @@ export default function shouldBehaveLikeCodexTitle(accounts) {
           await modifyMetadataHashes({
             newNameHash: hashedMetadata.name,
             newDescriptionHash: '',
-            newImageHashes: hashedMetadata.images,
+            newFileHashes: hashedMetadata.files,
 
             providerId,
             providerMetadataId,
@@ -210,11 +208,11 @@ export default function shouldBehaveLikeCodexTitle(accounts) {
           })
         })
 
-        it('should update image hashes only', async function () {
+        it('should update file hashes only', async function () {
           await modifyMetadataHashes({
             newNameHash: '',
             newDescriptionHash: hashedMetadata.description,
-            newImageHashes,
+            newFileHashes,
 
             providerId,
             providerMetadataId,
@@ -227,7 +225,7 @@ export default function shouldBehaveLikeCodexTitle(accounts) {
           await modifyMetadataHashes({
             newNameHash,
             newDescriptionHash,
-            newImageHashes,
+            newFileHashes,
 
             providerId,
             providerMetadataId,
@@ -238,7 +236,7 @@ export default function shouldBehaveLikeCodexTitle(accounts) {
           await modifyMetadataHashes({
             newNameHash,
             newDescriptionHash,
-            newImageHashes,
+            newFileHashes,
           })
         })
       })


### PR DESCRIPTION
Any objections to making `imageHashes` a little more generic? This will allow historical documentation to be stored in the same array as images, which should be okay since we're not really storing what image hash correlates to which image. When it comes time to verify files, it'll just have to be a "does the hash of this file exist in the smart contract's `fileHashes` array?"

I also made `mint()` require the whole `fileHashes` array instead of a single file, since I think this may be useful when third-parties start creating titles with pre-existing images & historical provenance.

Finally, I also removed `getImageHashByIndex()` since I don't believe it'll be useful (because we're not tracking which image is at which index anywhere.)