### PR TITLE
Adding discount structure for staking mechanism

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+coverage

--- a/contracts/CodexRecordAccess.sol
+++ b/contracts/CodexRecordAccess.sol
@@ -18,8 +18,8 @@ contract CodexRecordAccess is CodexRecordCore {
     bytes32 _descriptionHash,
     bytes32[] _fileHashes,
     string _providerId, // TODO: convert to bytes32
-    string _providerMetadataId ) // TODO: convert to bytes32
-
+    string _providerMetadataId // TODO: convert to bytes32
+  )
     public
     whenNotPaused
     canPayFees(creationFee)

--- a/contracts/CodexRecordAccess.sol
+++ b/contracts/CodexRecordAccess.sol
@@ -18,7 +18,8 @@ contract CodexRecordAccess is CodexRecordCore {
     bytes32 _descriptionHash,
     bytes32[] _fileHashes,
     string _providerId, // TODO: convert to bytes32
-    string _providerMetadataId) // TODO: convert to bytes32
+    string _providerMetadataId ) // TODO: convert to bytes32
+
     public
     whenNotPaused
     canPayFees(creationFee)
@@ -39,7 +40,8 @@ contract CodexRecordAccess is CodexRecordCore {
   function transferFrom(
     address _from,
     address _to,
-    uint256 _tokenId)
+    uint256 _tokenId
+  )
     public
     whenNotPaused
     canPayFees(transferFee)
@@ -53,7 +55,8 @@ contract CodexRecordAccess is CodexRecordCore {
   function safeTransferFrom(
     address _from,
     address _to,
-    uint256 _tokenId)
+    uint256 _tokenId
+  )
     public
     whenNotPaused
     canPayFees(transferFee)
@@ -68,7 +71,8 @@ contract CodexRecordAccess is CodexRecordCore {
     address _from,
     address _to,
     uint256 _tokenId,
-    bytes _data)
+    bytes _data
+  )
     public
     whenNotPaused
     canPayFees(transferFee)
@@ -90,7 +94,8 @@ contract CodexRecordAccess is CodexRecordCore {
     bytes32 _newDescriptionHash,
     bytes32[] _newFileHashes,
     string _providerId, // TODO: convert to bytes32?
-    string _providerMetadataId) // TODO: convert to bytes32?
+    string _providerMetadataId // TODO: convert to bytes32?
+  )
     public
     whenNotPaused
     canPayFees(modificationFee)

--- a/contracts/CodexRecordCore.sol
+++ b/contracts/CodexRecordCore.sol
@@ -8,7 +8,7 @@ import "./CodexRecordFees.sol";
  * @title CodexRecordCore
  * @dev Core functionality of the token, namely minting.
  */
-contract CodexRecordCore is CodexRecordMetadata, CodexRecordFees {
+contract CodexRecordCore is CodexRecordFees {
 
   /**
    * @dev This event is emitted when a new token is minted and allows providers

--- a/contracts/CodexRecordCore.sol
+++ b/contracts/CodexRecordCore.sol
@@ -41,7 +41,8 @@ contract CodexRecordCore is CodexRecordFees {
     bytes32 _descriptionHash,
     bytes32[] _fileHashes,
     string _providerId, // @TODO: convert to bytes32
-    string _providerMetadataId) // @TODO: convert to bytes32
+    string _providerMetadataId  // @TODO: convert to bytes32
+  )
     public
   {
     // For now, all new tokens will be the last entry in the array

--- a/contracts/CodexRecordCore.sol
+++ b/contracts/CodexRecordCore.sol
@@ -29,7 +29,9 @@ contract CodexRecordCore is CodexRecordFees {
 
   /**
    * @dev Creates a new token
-   * @dev @TODO: Fill in the rest of the params
+   * @param _to address The address the token will get transferred to after minting
+   * @param _nameHash bytes32 The sha3 hash of the name
+   * @param _descriptionHash bytes32 The sha3 hash of the description
    * @param _providerId string An ID that identifies which provider is
    *  minting this token
    * @param _providerMetadataId string An arbitrary provider-defined ID that

--- a/contracts/CodexRecordFees.sol
+++ b/contracts/CodexRecordFees.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.24;
 
+import "./CodexRecordMetadata.sol";
 import "./ERC20/ERC20.sol";
 import "./ERC900/ERC900.sol";
 
@@ -11,7 +12,7 @@ import "./library/Pausable.sol";
  * @dev Storage, mutators, and modifiers for fees when using the token.
  *  This also includes the Pausable contract for the onlyOwner modifier.
  */
-contract CodexRecordFees is Pausable {
+contract CodexRecordFees is CodexRecordMetadata, Pausable {
 
   // Implementation of the ERC20 Codex Protocol Token, used for fees in the contract
   ERC20 public codexCoin;
@@ -32,25 +33,34 @@ contract CodexRecordFees is Pausable {
   // Fee to modify tokens. 10^18 = 1 token
   uint256 public modificationFee = 0;
 
-  // Parameters in the polynomial used to calculate discount
-  // Current range of discount is 0-100% (i.e., stake enough tokens for a 100% discount!)
-  uint256 public lowerBound = 0;
-  uint256 public upperBound = 100;
+  // To receive a full discount on the protocol fees, stake this number of tokens
+  uint256 public tokensNeededForFullDiscount;
 
   modifier canPayFees(uint256 baseFee) {
     if (feeRecipient != address(0)) {
-      // @TODO: Update the discount to be based on weight as opposed to just
-      //  a binary on/off value
       uint256 calculatedFee = baseFee;
-      if (codexStakeContainer != address(0) &&
-        codexStakeContainer.totalStakedFor(msg.sender) > 0) {
 
-        calculatedFee = 0;
+      if (codexStakeContainer != address(0) && tokensNeededForFullDiscount > 0) {
+        uint256 totalStakedFor = codexStakeContainer.totalStakedFor(msg.sender);
+
+        if (totalStakedFor > 0) {
+          // Since floating point operations aren't supported in the EVM, we need to use a divisor to simulate fractions
+          uint256 divisor = 1 ether;
+
+          // The calculated discount is a % of tokens staked against the tokens needed to be staked
+          // e.g., if tokensNeededForFullDiscount is 100, and totalStakedFor is 50, the calculated discount is 50%
+          uint256 calculatedDiscount = totalStakedFor.mul(divisor).div(tokensNeededForFullDiscount);
+
+          // Update the fee based on the calculated discount, using the divisor again to convert back to the appropriate units
+          calculatedFee = baseFee.mul(divisor.sub(calculatedDiscount)).div(divisor);
+        }
       }
 
-      require(
-        codexCoin.transferFrom(msg.sender, feeRecipient, calculatedFee),
-        "Fee in CODX required");
+      if (calculatedFee > 0) {
+        require(
+          codexCoin.transferFrom(msg.sender, feeRecipient, calculatedFee),
+          "Fee in CODX required");
+      }
     }
 
     _;
@@ -71,7 +81,8 @@ contract CodexRecordFees is Pausable {
     uint256 _creationFee,
     uint256 _transferFee,
     uint256 _modificationFee)
-    external onlyOwner
+    external
+    onlyOwner
   {
     codexCoin = _codexCoin;
     feeRecipient = _feeRecipient;
@@ -82,5 +93,18 @@ contract CodexRecordFees is Pausable {
 
   function setStakeContainer(ERC900 _codexStakeContainer) external onlyOwner {
     codexStakeContainer = _codexStakeContainer;
+  }
+
+  /**
+   * @dev Sets the number of tokens needed to be staked in order to
+   * receive a 100% discount on the contract fees. 10^18 is 1 token.
+   * @param _tokensNeededForFullDiscount uint256 The number of tokens needed
+   */
+  function setTokensNeededForFullDiscount(
+    uint256 _tokensNeededForFullDiscount)
+    external
+    onlyOwner
+  {
+    tokensNeededForFullDiscount = _tokensNeededForFullDiscount;
   }
 }

--- a/contracts/CodexRecordFees.sol
+++ b/contracts/CodexRecordFees.sol
@@ -83,7 +83,8 @@ contract CodexRecordFees is CodexRecordMetadata, Pausable {
     address _feeRecipient,
     uint256 _creationFee,
     uint256 _transferFee,
-    uint256 _modificationFee)
+    uint256 _modificationFee
+  )
     external
     onlyOwner
   {
@@ -104,7 +105,8 @@ contract CodexRecordFees is CodexRecordMetadata, Pausable {
    * @param _tokensNeededForFullDiscount uint256 The number of tokens needed
    */
   function setTokensNeededForFullDiscount(
-    uint256 _tokensNeededForFullDiscount)
+    uint256 _tokensNeededForFullDiscount
+  )
     external
     onlyOwner
   {

--- a/contracts/CodexRecordFees.sol
+++ b/contracts/CodexRecordFees.sol
@@ -43,7 +43,10 @@ contract CodexRecordFees is CodexRecordMetadata, Pausable {
       if (codexStakeContainer != address(0) && tokensNeededForFullDiscount > 0) {
         uint256 totalStakedFor = codexStakeContainer.totalStakedFor(msg.sender);
 
-        if (totalStakedFor > 0) {
+        // Discounts are capped at 100% :)
+        if (totalStakedFor > tokensNeededForFullDiscount) {
+          calculatedFee = 0;
+        } else if (totalStakedFor > 0) {
           // Since floating point operations aren't supported in the EVM, we need to use a divisor to simulate fractions
           uint256 divisor = 1 ether;
 

--- a/contracts/CodexRecordMetadata.sol
+++ b/contracts/CodexRecordMetadata.sol
@@ -45,9 +45,13 @@ contract CodexRecordMetadata is ERC721Token {
 
   /**
    * @dev Updates token metadata hashes to whatever is passed in
-   * @param _providerId (optional) An ID that identifies which provider is
+   * @param _tokenId uint256 The token ID
+   * @param _newNameHash bytes32 The new sha3 hash of the name
+   * @param _newDescriptionHash bytes32 The new sha3 hash of the description
+   * @param _newFileHashes bytes32[] The new sha3 hashes of the files associated with the token
+   * @param _providerId (optional) string An ID that identifies which provider is
    *  minting this token
-   * @param _providerMetadataId (optional) An arbitrary provider-defined ID that
+   * @param _providerMetadataId (optional) string An arbitrary provider-defined ID that
    *  identifies the metadata record stored by the provider
    */
   function modifyMetadataHashes(

--- a/contracts/CodexRecordMetadata.sol
+++ b/contracts/CodexRecordMetadata.sol
@@ -56,7 +56,8 @@ contract CodexRecordMetadata is ERC721Token {
     bytes32 _newDescriptionHash,
     bytes32[] _newFileHashes,
     string _providerId, // TODO: convert to bytes32?
-    string _providerMetadataId) // TODO: convert to bytes32?
+    string _providerMetadataId  // TODO: convert to bytes32?
+  )
     tokenExists(_tokenId)
     public onlyOwnerOf(_tokenId)
   {
@@ -102,7 +103,9 @@ contract CodexRecordMetadata is ERC721Token {
    * @param _tokenId token ID
    * @return CodexRecordData token data for the given token ID
    */
-  function getTokenById(uint256 _tokenId)
+  function getTokenById(
+    uint256 _tokenId
+  )
     public
     view
     tokenExists(_tokenId)
@@ -131,7 +134,9 @@ contract CodexRecordMetadata is ERC721Token {
    *
    * @param _tokenId uint256 ID of the token to query
    */
-  function tokenURI(uint256 _tokenId)
+  function tokenURI(
+    uint256 _tokenId
+  )
     public
     view
     tokenExists(_tokenId)

--- a/contracts/CodexStakeContainer.sol
+++ b/contracts/CodexStakeContainer.sol
@@ -1,16 +1,30 @@
 pragma solidity ^0.4.24;
 
 import "./ERC900/ERC900BasicStakeContainer.sol";
+
+// @TODO: Add Pausable functionality to prevent staking/unstaking?
 import "./library/Pausable.sol";
 
 
+/**
+ * @title CodexStakeContainer
+ */
 contract CodexStakeContainer is ERC900BasicStakeContainer, Pausable {
+  /**
+   * @dev Constructor function
+   * @param _stakingToken ERC20 The address of the token used for staking
+   * @param _lockInDuration uint256 The duration (in seconds) that stakes are required to be locked for
+   */
   constructor(ERC20 _stakingToken, uint256 _lockInDuration) public
     ERC900BasicStakeContainer(_stakingToken)
   {
     lockInDuration = _lockInDuration;
   }
 
+  /**
+   * @dev Sets the lockInDuration for stakes. Only callable by the owner
+   * @param _lockInDuration uint256 The duration (in seconds) that stakes are required to be locked for
+   */
   function setLockInDuration(uint256 _lockInDuration) external onlyOwner {
     lockInDuration = _lockInDuration;
   }

--- a/contracts/CodexStakeContainer.sol
+++ b/contracts/CodexStakeContainer.sol
@@ -14,11 +14,13 @@ contract CodexStakeContainer is ERC900BasicStakeContainer, Pausable {
    * @dev Constructor function
    * @param _stakingToken ERC20 The address of the token used for staking
    * @param _lockInDuration uint256 The duration (in seconds) that stakes are required to be locked for
+   * @param _annualizedInterestRate uint256 The interest rate (in wei) that stakes can receive on a yearly basis
    */
-  constructor(ERC20 _stakingToken, uint256 _lockInDuration) public
+  constructor(ERC20 _stakingToken, uint256 _lockInDuration, uint256 _annualizedInterestRate) public
     ERC900BasicStakeContainer(_stakingToken)
   {
     lockInDuration = _lockInDuration;
+    annualizedInterestRate = _annualizedInterestRate;
   }
 
   /**
@@ -27,5 +29,13 @@ contract CodexStakeContainer is ERC900BasicStakeContainer, Pausable {
    */
   function setLockInDuration(uint256 _lockInDuration) external onlyOwner {
     lockInDuration = _lockInDuration;
+  }
+
+  /**
+   * @dev Sets the interest rate for the perceivedAmount on stakes. Only callable by the owner.
+   * @param _annualizedInterestRate uint256 The annualized interest rate (in wei)
+   */
+  function setAnnualizedInterestRate(uint256 _annualizedInterestRate) external onlyOwner {
+    annualizedInterestRate = _annualizedInterestRate;
   }
 }

--- a/contracts/ERC900/ERC900BasicStakeContainer.sol
+++ b/contracts/ERC900/ERC900BasicStakeContainer.sol
@@ -21,6 +21,11 @@ contract ERC900BasicStakeContainer is ERC900 {
   // The duration of stake lock-in (in seconds)
   uint256 public lockInDuration;
 
+  // For token staked longer than a year, they will become more valuable by this coefficient
+  // e.g., if inflationRate is 10, after 1 year the perceived stake is 10% more valuable
+  // @TODO: come back to this
+  // uint256 public inflationRate;
+
   // To save on gas, rather than create a separate mapping for amountStakedFor & personalStake,
   //  both data structures are stored in a single mapping for a given addresses.
   //

--- a/contracts/ERC900/ERC900BasicStakeContainer.sol
+++ b/contracts/ERC900/ERC900BasicStakeContainer.sol
@@ -22,27 +22,33 @@ contract ERC900BasicStakeContainer is ERC900 {
   uint256 public lockInDuration;
 
   // For token staked longer than a year, they will become more valuable by this coefficient
-  // e.g., if inflationRate is 10, after 1 year the perceived stake is 10% more valuable
-  // @TODO: come back to this
-  // uint256 public inflationRate;
+  //  e.g., if interestRate is 10, after 1 year the perceived stake is 10% more valuable.
+  // Stakeholders will have to ping the contract via updatePerceivedStakeAmounts to have
+  //  the contract update the perceived amounts of their stakes.
+  uint256 public annualizedInterestRate;
 
-  // To save on gas, rather than create a separate mapping for amountStakedFor & personalStake,
+  // The number of seconds in a year (365.25 days)
+  // Used for determining when stakes are eligible for interest
+  uint256 constant public YEAR_IN_SECONDS = 31557600;
+
+  // To save on gas, rather than create a separate mapping for totalStakedFor & personalStakes,
   //  both data structures are stored in a single mapping for a given addresses.
   //
-  // totalStakedFor consists of all tokens staked for a given address.
-  // personalStake is the stake made by a given address.
-  //
-  // It's possible to have a non-existing personalStake, but have tokens in amountStakedFor
+  // It's possible to have a non-existing personalStakes, but have tokens in totalStakedFor
   //  if other users are staking on behalf of a given address.
   mapping (address => StakeContainer) public stakeHolders;
 
   // Struct for personal stakes (i.e., stakes made by this address)
+  // lastUpdatedTimestamp - when the perceivedAmount of the stake was last updated
   // unlockedTimestamp - when the stake unlocks (in seconds since Unix epoch)
-  // amount - the amount of tokens in the stake
+  // actualAmount - the amount of tokens in the stake
+  // perceivedAmount - the weighted amount of tokens in the stake
   // stakedFor - the address the stake was staked for
   struct Stake {
+    uint256 lastUpdatedTimestamp;
     uint256 unlockedTimestamp;
-    uint256 amount;
+    uint256 actualAmount;
+    uint256 perceivedAmount;
     address stakedFor;
   }
 
@@ -92,22 +98,35 @@ contract ERC900BasicStakeContainer is ERC900 {
    */
   function getPersonalStakeUnlockedTimestamps(address _address) external view returns (uint256[]) {
     uint256[] memory timestamps;
-    (timestamps,,) = getPersonalStakes(_address);
+    (timestamps,,,) = getPersonalStakes(_address);
 
     return timestamps;
   }
 
   /**
-   * @dev Returns the stake amounts for active personal stakes for an address
+   * @dev Returns the stake actualAmount for active personal stakes for an address
    * @dev These accessors functions are needed until https://github.com/ethereum/web3.js/issues/1241 is solved
    * @param _address address that created the stakes
-   * @return uint256[] array of amounts
+   * @return uint256[] array of actualAmounts
    */
-  function getPersonalStakeAmounts(address _address) external view returns (uint256[]) {
-    uint256[] memory amounts;
-    (,amounts,) = getPersonalStakes(_address);
+  function getPersonalStakeActualAmounts(address _address) external view returns (uint256[]) {
+    uint256[] memory actualAmounts;
+    (,actualAmounts,,) = getPersonalStakes(_address);
 
-    return amounts;
+    return actualAmounts;
+  }
+
+  /**
+   * @dev Returns the stake perceivedAmount for active personal stakes for an address
+   * @dev These accessors functions are needed until https://github.com/ethereum/web3.js/issues/1241 is solved
+   * @param _address address that created the stakes
+   * @return uint256[] array of perceivedAmounts
+   */
+  function getPersonalStakePerceivedAmounts(address _address) external view returns (uint256[]) {
+    uint256[] memory perceivedAmounts;
+    (,,perceivedAmounts,) = getPersonalStakes(_address);
+
+    return perceivedAmounts;
   }
 
   /**
@@ -118,9 +137,38 @@ contract ERC900BasicStakeContainer is ERC900 {
    */
   function getPersonalStakeForAddresses(address _address) external view returns (address[]) {
     address[] memory stakedFor;
-    (,,stakedFor) = getPersonalStakes(_address);
+    (,,,stakedFor) = getPersonalStakes(_address);
 
     return stakedFor;
+  }
+
+  /**
+   * @dev Updates the perceivedAmount for all personal stakes at the given address
+   * @param _address The address to update personal stakes
+   */
+  function updatePerceivedStakeAmounts(address _address) external {
+    StakeContainer storage stakeContainer = stakeHolders[_address];
+
+    for (uint256 i = stakeContainer.personalStakeIndex; i < stakeContainer.personalStakes.length; i++) {
+      Stake storage currentStake = stakeContainer.personalStakes[i];
+
+      if (block.timestamp.sub(currentStake.lastUpdatedTimestamp) > YEAR_IN_SECONDS) {
+        uint256 unit = 1 ether;
+
+        uint256 newAmount = currentStake.perceivedAmount.mul(annualizedInterestRate.add(unit)).div(unit);
+        uint256 difference = newAmount.sub(currentStake.perceivedAmount);
+
+        // Update the totalStakedFor with the interest received
+        stakeHolders[currentStake.stakedFor].totalStakedFor = stakeHolders[currentStake.stakedFor].totalStakedFor.add(difference);
+
+        // Update the perceivedAmount with the interest received
+        currentStake.perceivedAmount = newAmount;
+
+        // Update the timestamp, so this stake is only eligible for interest a year from now
+        // @TODO: The logic isn't great right now. If my stake exists for 3 years, but I only ping once, I only receive 10% interest.
+        currentStake.lastUpdatedTimestamp = block.timestamp;
+      }
+    }
   }
 
   /**
@@ -168,8 +216,8 @@ contract ERC900BasicStakeContainer is ERC900 {
       "The current stake hasn't unlocked yet");
 
     require(
-      personalStake.amount == _amount,
-      "The current stake doesn't match the unstake amount");
+      personalStake.actualAmount == _amount,
+      "The unstake amount does not match the current stake");
 
     // Transfer the staked tokens from this contract back to the sender
     // Notice that we are using transfer instead of transferFrom here, so
@@ -178,8 +226,13 @@ contract ERC900BasicStakeContainer is ERC900 {
       stakingToken.transfer(msg.sender, _amount),
       "Unable to withdraw stake");
 
-    stakeHolders[personalStake.stakedFor].totalStakedFor = stakeHolders[personalStake.stakedFor].totalStakedFor.sub(personalStake.amount);
-    personalStake.amount = 0;
+    // Notice that we are reducing totalStakedFor by the perceivedAmount of tokens in case any interest had accrued
+    //  in the stakes for that address
+    stakeHolders[personalStake.stakedFor].totalStakedFor = stakeHolders[personalStake.stakedFor]
+      .totalStakedFor.sub(personalStake.perceivedAmount);
+
+    personalStake.actualAmount = 0;
+    personalStake.perceivedAmount = 0;
     stakeHolders[msg.sender].personalStakeIndex++;
 
     emit Unstaked(
@@ -232,7 +285,8 @@ contract ERC900BasicStakeContainer is ERC900 {
   function createStake(
     address _address,
     uint256 _amount,
-    bytes _data)
+    bytes _data
+  )
     internal
     canStake(msg.sender, _amount)
   {
@@ -243,7 +297,9 @@ contract ERC900BasicStakeContainer is ERC900 {
     stakeHolders[_address].totalStakedFor = stakeHolders[_address].totalStakedFor.add(_amount);
     stakeHolders[msg.sender].personalStakes.push(
       Stake(
+        block.timestamp,
         block.timestamp.add(lockInDuration),
+        _amount,
         _amount,
         _address)
       );
@@ -258,26 +314,36 @@ contract ERC900BasicStakeContainer is ERC900 {
   /**
    * @dev Helper function to get specific properties of all of the personal stakes created by an address
    * @param _address address The address to query
-   * @return (uint256[], uint256[], address[]) timestamps array, amounts array, stakedFor array
+   * @return (uint256[], uint256[], uint256[], address[])
+   *  timestamps array, actualAmounts array, perceivedAmounts array, stakedFor array
    */
-  function getPersonalStakes(address _address) view private returns(uint256[], uint256[], address[]) {
+  function getPersonalStakes(
+    address _address
+  )
+    view
+    private
+    returns(uint256[], uint256[], uint256[], address[])
+  {
     StakeContainer storage stakeContainer = stakeHolders[_address];
 
     uint256 arraySize = stakeContainer.personalStakes.length - stakeContainer.personalStakeIndex;
     uint256[] memory unlockedTimestamps = new uint256[](arraySize);
-    uint256[] memory amounts = new uint256[](arraySize);
+    uint256[] memory actualAmounts = new uint256[](arraySize);
+    uint256[] memory perceivedAmounts = new uint256[](arraySize);
     address[] memory stakedFor = new address[](arraySize);
 
     for (uint256 i = stakeContainer.personalStakeIndex; i < stakeContainer.personalStakes.length; i++) {
       uint256 index = i - stakeContainer.personalStakeIndex;
       unlockedTimestamps[index] = stakeContainer.personalStakes[i].unlockedTimestamp;
-      amounts[index] = stakeContainer.personalStakes[i].amount;
+      actualAmounts[index] = stakeContainer.personalStakes[i].actualAmount;
+      perceivedAmounts[index] = stakeContainer.personalStakes[i].perceivedAmount;
       stakedFor[index] = stakeContainer.personalStakes[i].stakedFor;
     }
 
     return (
       unlockedTimestamps,
-      amounts,
+      actualAmounts,
+      perceivedAmounts,
       stakedFor
     );
   }

--- a/contracts/ERC900/ERC900BasicStakeContainer.sol
+++ b/contracts/ERC900/ERC900BasicStakeContainer.sol
@@ -156,7 +156,7 @@ contract ERC900BasicStakeContainer is ERC900 {
       // If interest has accrued over multiple years, the actual interest received will be higher than the
       //  annualized interest rate, so we use a loop to accrue this over multiple years
       // @TODO: There are some gas optimizations that can be made here (i.e., calculated the compoundedInterest rate)
-      while (block.timestamp.sub(lastUpdatedTimestamp) > YEAR_IN_SECONDS) {
+      while (block.timestamp.sub(lastUpdatedTimestamp) >= YEAR_IN_SECONDS) {
         uint256 unit = 1 ether;
 
         uint256 newAmount = currentStake.perceivedAmount.mul(annualizedInterestRate.add(unit)).div(unit);

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.24;
 
+
 /**
  * @title Migrations
  * @dev Truffle migrations contract, used for deployment only

--- a/contracts/library/Debuggable.sol
+++ b/contracts/library/Debuggable.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.4.24;
+
+
+/**
+ * @title Debuggable, a utility contract to assist in debugging
+ * @notice FOR LOCAL DEVELOPMENT ONLY!
+ * @dev provides a bunch of events that can be emitted in smart contracts to aid in debugging.
+ *  Think of it like console.log for Solidity.
+ * @dev Fill in new data types as needed.
+ */
+contract Debuggable {
+  event DebugUint256(uint256 value);
+  event DebugString(string value);
+  event DebugAddress(address value);
+}

--- a/contracts/mocks/ERC20/CodexCoin.sol
+++ b/contracts/mocks/ERC20/CodexCoin.sol
@@ -1,10 +1,12 @@
 pragma solidity ^0.4.24;
 
-import "./StandardToken.sol";
-import "../../library/Pausable.sol";
+import "./PausableToken.sol";
 
 
-contract CodexCoin is StandardToken, Pausable {
+/**
+ * @title CodexCoin, an ERC-20 token
+ */
+contract CodexCoin is PausableToken {
 
   /* solium-disable uppercase */
   uint8 constant public decimals = 18;

--- a/contracts/mocks/ERC20/PausableToken.sol
+++ b/contracts/mocks/ERC20/PausableToken.sol
@@ -1,0 +1,68 @@
+pragma solidity ^0.4.24;
+
+import "./StandardToken.sol";
+import "../../library/Pausable.sol";
+
+
+/**
+ * @title Pausable token
+ * @dev StandardToken modified with pausable transfers.
+ **/
+contract PausableToken is StandardToken, Pausable {
+
+  function transfer(
+    address _to,
+    uint256 _value
+  )
+    public
+    whenNotPaused
+    returns (bool)
+  {
+    return super.transfer(_to, _value);
+  }
+
+  function transferFrom(
+    address _from,
+    address _to,
+    uint256 _value
+  )
+    public
+    whenNotPaused
+    returns (bool)
+  {
+    return super.transferFrom(_from, _to, _value);
+  }
+
+  function approve(
+    address _spender,
+    uint256 _value
+  )
+    public
+    whenNotPaused
+    returns (bool)
+  {
+    return super.approve(_spender, _value);
+  }
+
+  function increaseApproval(
+    address _spender,
+    uint _addedValue
+  )
+    public
+    whenNotPaused
+    returns (bool success)
+  {
+    return super.increaseApproval(_spender, _addedValue);
+  }
+
+  function decreaseApproval(
+    address _spender,
+    uint _subtractedValue
+  )
+    public
+    whenNotPaused
+    returns (bool success)
+  {
+    return super.decreaseApproval(_spender, _subtractedValue);
+  }
+}

--- a/licenses/OZ_LICENSE
+++ b/licenses/OZ_LICENSE
@@ -10,6 +10,7 @@ contracts/ERC721/ERC721Receiver.sol
 contracts/ERC721/ERC721Token.sol
 
 contracts/mocks/ERC20/BasicToken.sol
+contracts/mocks/ERC20/PausableToken.sol
 contracts/mocks/ERC20/StandardToken.sol
 contracts/mocks/ERC721/ERC721BasicTokenMock.sol
 contracts/mocks/ERC721/ERC721ReceiverMock.sol

--- a/migrations/3_deploy_stakecontainer.js
+++ b/migrations/3_deploy_stakecontainer.js
@@ -4,12 +4,21 @@ const CodexStakeContainer = artifacts.require('./CodexStakeContainer.sol')
 module.exports = (deployer, network) => {
   deployer.then(async () => {
     let codexCoinAddress
+    let lockInDuration
+    let annualizedInterestRate
+
     switch (network) {
       case 'ganache':
       case 'develop':
       case 'test':
       case 'coverage':
         codexCoinAddress = CodexCoin.address
+
+        // 90 days (in seconds)
+        lockInDuration = 7776000
+
+        // 10% annually
+        annualizedInterestRate = web3.toWei(0.1, 'ether')
         break
 
       case 'rinkeby': {
@@ -21,9 +30,12 @@ module.exports = (deployer, network) => {
         throw new Error('No erc20TokenAddress & initialFees defined for this network')
     }
 
-    // 90 days (in seconds)
-    const lockInDuration = 7776000
-    await deployer.deploy(CodexStakeContainer, codexCoinAddress, lockInDuration)
+    await deployer.deploy(
+      CodexStakeContainer,
+      codexCoinAddress,
+      lockInDuration,
+      annualizedInterestRate,
+    )
   })
 
 }

--- a/migrations/6_initialize_721token.js
+++ b/migrations/6_initialize_721token.js
@@ -10,20 +10,22 @@ module.exports = async (deployer, network, accounts) => {
     .then(async () => {
       let initialFees
       let erc20TokenAddress
+      let tokensNeededForFullDiscount
 
       switch (network) {
         case 'ganache':
         case 'develop':
         case 'test':
         case 'coverage': {
-          erc20TokenAddress = CodexCoin.address
           initialFees = 0
+          erc20TokenAddress = CodexCoin.address
+          tokensNeededForFullDiscount = web3.toWei(10000, 'ether')
           break
         }
 
         case 'rinkeby':
-          erc20TokenAddress = '0xb902c00f8e5aced53e2a513903fd831d32dd1097'
           initialFees = web3.toWei(1, 'ether')
+          erc20TokenAddress = '0xb902c00f8e5aced53e2a513903fd831d32dd1097'
           break
 
         default:
@@ -37,6 +39,10 @@ module.exports = async (deployer, network, accounts) => {
         initialFees, // creationFee
         initialFees, // transferFee
         initialFees, // modificationFee
+      )
+
+      await proxiedCodexRecord.setTokensNeededForFullDiscount(
+        tokensNeededForFullDiscount
       )
 
       await proxiedCodexRecord.setStakeContainer(

--- a/test/behaviors/CodexRecordFees.behavior.js
+++ b/test/behaviors/CodexRecordFees.behavior.js
@@ -104,7 +104,7 @@ export default function shouldBehaveLikeCodexRecordWithFees(accounts, metadata) 
       let stakeContainer
 
       beforeEach(async function () {
-        stakeContainer = await CodexStakeContainer.new(this.codexCoin.address, 7776000)
+        stakeContainer = await CodexStakeContainer.new(this.codexCoin.address, 7776000, web3.toWei(0.1, 'ether'))
 
         await this.token.setStakeContainer(stakeContainer.address)
         await this.token.setTokensNeededForFullDiscount(web3.toWei(10, 'ether'))

--- a/test/behaviors/CodexRecordFees.behavior.js
+++ b/test/behaviors/CodexRecordFees.behavior.js
@@ -152,7 +152,12 @@ export default function shouldBehaveLikeCodexRecordWithFees(accounts, metadata) 
         const currentBalance = await codexCoin.balanceOf(creator)
         const amountPaid = balanceAfterStaking.minus(currentBalance)
 
-        amountPaid.should.be.bignumber.equal(undiscountedFee.times(1 - expectedDiscount))
+        let discountMultiplier = 1 - expectedDiscount
+        if (expectedDiscount > 1) {
+          discountMultiplier = 0 // 100% discount
+        }
+
+        amountPaid.should.be.bignumber.equal(undiscountedFee.times(discountMultiplier))
       }
 
       it('should not reduce the fees paid if no tokens are staked', async function () {
@@ -165,6 +170,10 @@ export default function shouldBehaveLikeCodexRecordWithFees(accounts, metadata) 
 
       it('should eliminate fees if enough tokens are staked', async function () {
         await testDiscount(this.codexCoin, this.token, 1)
+      })
+
+      it('should eliminate fees if more than enough tokens are staked', async function () {
+        await testDiscount(this.codexCoin, this.token, 2)
       })
     })
 

--- a/test/core/CodexStakeContainer.test.js
+++ b/test/core/CodexStakeContainer.test.js
@@ -207,9 +207,12 @@ contract('CodexStakeContainer', function (accounts) {
       it('should emit a Staked event', async function () {
         const { logs } = tx
 
-        // @TODO validate other params
         logs.length.should.be.equal(1)
         logs[0].event.should.be.equal('Staked')
+        logs[0].args.user.should.be.equal(creator)
+        logs[0].args.amount.should.be.bignumber.equal(stakeAmount)
+        logs[0].args.total.should.be.bignumber.equal(stakeAmount)
+        logs[0].args.data.should.be.equal('0x')
       })
 
       it('should be eligible for interest after 1 year', async function () {
@@ -249,12 +252,13 @@ contract('CodexStakeContainer', function (accounts) {
 
   describe('stakeFor', function () {
     describe('when a user stakes on behalf of another user', function () {
+      const stakeAmount = web3.toWei(1, 'ether')
       let originalTotalStakedFor
       let tx
 
       beforeEach(async function () {
         originalTotalStakedFor = await this.stakeContainer.totalStakedFor(creator)
-        tx = await this.stakeContainer.stakeFor(otherUser, web3.toWei(1, 'ether'), 0x0)
+        tx = await this.stakeContainer.stakeFor(otherUser, stakeAmount, 0x0)
       })
 
       it('should create a personal stake for the staker', async function () {
@@ -270,15 +274,18 @@ contract('CodexStakeContainer', function (accounts) {
 
       it('should increase the number of tokens staked for the other user', async function () {
         const totalStakedForOtherUser = await this.stakeContainer.totalStakedFor(otherUser)
-        totalStakedForOtherUser.should.be.bignumber.equal(web3.toWei(1, 'ether'))
+        totalStakedForOtherUser.should.be.bignumber.equal(stakeAmount)
       })
 
       it('should emit a Staked event', async function () {
         const { logs } = tx
 
-        // @TODO validate other params
         logs.length.should.be.equal(1)
         logs[0].event.should.be.equal('Staked')
+        logs[0].args.user.should.be.equal(otherUser)
+        logs[0].args.amount.should.be.bignumber.equal(stakeAmount)
+        logs[0].args.total.should.be.bignumber.equal(stakeAmount)
+        logs[0].args.data.should.be.equal('0x')
       })
     })
   })
@@ -321,6 +328,7 @@ contract('CodexStakeContainer', function (accounts) {
     })
 
     describe('when called correctly', function () {
+      const unstakeAmount = web3.toWei(10, 'ether')
       let tx
       let originalBalance
 
@@ -330,15 +338,18 @@ contract('CodexStakeContainer', function (accounts) {
 
         originalBalance = await this.codexCoin.balanceOf(creator)
 
-        tx = await this.stakeContainer.unstake(web3.toWei(10, 'ether'), 0x0)
+        tx = await this.stakeContainer.unstake(unstakeAmount, 0x0)
       })
 
       it('should emit an Unstaked event', async function () {
         const { logs } = tx
 
-        // @TODO validate other params
         logs.length.should.be.equal(1)
         logs[0].event.should.be.equal('Unstaked')
+        logs[0].args.user.should.be.equal(creator)
+        logs[0].args.amount.should.be.bignumber.equal(unstakeAmount)
+        logs[0].args.total.should.be.bignumber.equal(0)
+        logs[0].args.data.should.be.equal('0x')
       })
 
       it('should decrement the number of the personal stakes', async function () {
@@ -354,14 +365,110 @@ contract('CodexStakeContainer', function (accounts) {
   })
 
   describe('updatePerceivedStakeAmounts', function () {
-    it('should not change the perceivedAmount for stakes that are not a year old')
-    it('should not change the perceivedAmount for stakes that have just received interest')
-    it('should update the perceivedAmount for all personalStakes that are eligible for interest')
+    const intendedInterestRate = 1.1 // 10% interest rate
+    const originalStakeAmount = web3.toWei(1, 'ether')
+    let stakeAmountWithInterest
 
-    // @TODO: Should this be compounding? Trying to optimize for gas here
-    it('should receive interest for every additional year of age (not compounding)')
-    it('should update the tokensStakedFor of the intended recipient')
-    it('should not update the totalStaked tokens in the contract')
-    it('should not update the actualAmount of tokens staked')
+    beforeEach(async function () {
+      await this.stakeContainer.stake(originalStakeAmount, 0x0)
+
+      const yearInSeconds = await this.stakeContainer.YEAR_IN_SECONDS()
+      await increaseTime(yearInSeconds.toNumber() + 500) // adding some extra buffer
+
+      const originalPerceivedAmounts = await this.stakeContainer.getPersonalStakePerceivedAmounts(creator)
+      originalPerceivedAmounts.length.should.be.bignumber.equal(1)
+      originalPerceivedAmounts[0].should.be.bignumber.equal(originalStakeAmount)
+
+      await this.stakeContainer.stake(originalStakeAmount, 0x0)
+      await this.stakeContainer.updatePerceivedStakeAmounts(creator)
+
+      const interestRate = await this.stakeContainer.annualizedInterestRate()
+      interestRate.should.be.bignumber.equal(web3.toWei(0.1, 'ether'))
+
+      const newPerceivedAmounts = await this.stakeContainer.getPersonalStakePerceivedAmounts(creator)
+      newPerceivedAmounts.length.should.be.bignumber.equal(2)
+
+      stakeAmountWithInterest = newPerceivedAmounts[0]
+      stakeAmountWithInterest.should.be.bignumber.equal(originalPerceivedAmounts[0].times(intendedInterestRate))
+    })
+
+    it('should not change the perceivedAmount for stakes that are not a year old', async function () {
+      const perceivedAmounts = await this.stakeContainer.getPersonalStakePerceivedAmounts(creator)
+      perceivedAmounts.length.should.be.bignumber.equal(2)
+      perceivedAmounts[1].should.be.bignumber.equal(originalStakeAmount)
+    })
+
+    it('should not change the perceivedAmount for stakes that have just received interest', async function () {
+      await this.stakeContainer.updatePerceivedStakeAmounts(creator)
+
+      const perceivedAmounts = await this.stakeContainer.getPersonalStakePerceivedAmounts(creator)
+      perceivedAmounts.length.should.be.bignumber.equal(2)
+      perceivedAmounts[0].should.be.bignumber.equal(stakeAmountWithInterest)
+    })
+
+    it('should update the perceivedAmount for all personalStakes that are eligible for interest', async function () {
+      await this.stakeContainer.stake(originalStakeAmount, 0x0)
+      await this.stakeContainer.stake(originalStakeAmount, 0x0)
+
+      const yearInSeconds = await this.stakeContainer.YEAR_IN_SECONDS()
+      await increaseTime(yearInSeconds.toNumber() + 500) // adding some extra buffer
+      await this.stakeContainer.updatePerceivedStakeAmounts(creator)
+
+      const perceivedAmounts = await this.stakeContainer.getPersonalStakePerceivedAmounts(creator)
+      perceivedAmounts.length.should.be.bignumber.equal(4)
+      perceivedAmounts[0].should.be.bignumber.equal(stakeAmountWithInterest.times(intendedInterestRate))
+
+      for (let i = 1; i < perceivedAmounts.length; i++) {
+        perceivedAmounts[i].should.be.bignumber.equal(stakeAmountWithInterest)
+      }
+    })
+
+    it('should receive interest after another year', async function () {
+      const yearInSeconds = await this.stakeContainer.YEAR_IN_SECONDS()
+      await increaseTime(yearInSeconds.toNumber() + 500) // adding some extra buffer
+      await this.stakeContainer.updatePerceivedStakeAmounts(creator)
+
+      const perceivedAmounts = await this.stakeContainer.getPersonalStakePerceivedAmounts(creator)
+      perceivedAmounts.length.should.be.bignumber.equal(2)
+      perceivedAmounts[0].should.be.bignumber.equal(stakeAmountWithInterest.times(intendedInterestRate))
+    })
+
+    it('should receive interest for every additional year of age (not compounding)', async function () {
+      const yearInSeconds = await this.stakeContainer.YEAR_IN_SECONDS()
+      await increaseTime((yearInSeconds.toNumber() * 3) + 500) // adding some extra buffer
+
+      await this.stakeContainer.updatePerceivedStakeAmounts(creator)
+
+      const perceivedAmounts = await this.stakeContainer.getPersonalStakePerceivedAmounts(creator)
+      perceivedAmounts.length.should.be.bignumber.equal(2)
+
+      // At this point, the first stake should have received 4 years of interest
+      const stakeAmount = new BigNumber(originalStakeAmount)
+      let compoundedInterestRate = (intendedInterestRate ** 4).toFixed(5)
+      perceivedAmounts[0].should.be.bignumber.equal(stakeAmount.times(compoundedInterestRate))
+
+      // And the second stake should have received 3 years of interest
+      compoundedInterestRate = (intendedInterestRate ** 3).toFixed(5)
+      perceivedAmounts[1].should.be.bignumber.equal(stakeAmount.times(compoundedInterestRate))
+    })
+
+    it('should update the tokensStakedFor of the intended recipient', async function () {
+      const totalStakedFor = await this.stakeContainer.totalStakedFor(creator)
+      totalStakedFor.should.be.bignumber.equal(new BigNumber(originalStakeAmount).plus(new BigNumber(stakeAmountWithInterest)))
+    })
+
+    it('should not update the totalStaked tokens in the contract', async function () {
+      const totalStaked = await this.stakeContainer.totalStaked()
+      totalStaked.should.be.bignumber.equal(new BigNumber(originalStakeAmount).plus(new BigNumber(originalStakeAmount)))
+    })
+
+    it('should not update the actualAmount of tokens staked', async function () {
+      const actualAmounts = await this.stakeContainer.getPersonalStakeActualAmounts(creator)
+      actualAmounts.length.should.be.bignumber.equal(2)
+
+      for (let i = 0; i < actualAmounts.length; i++) {
+        actualAmounts[i].should.be.bignumber.equal(originalStakeAmount)
+      }
+    })
   })
 })

--- a/test/helpers/printDebuggableLogs.js
+++ b/test/helpers/printDebuggableLogs.js
@@ -1,0 +1,9 @@
+export default function (rawLogs) {
+  for (let i = 0; i < rawLogs.length; i++) {
+    console.log(rawLogs[i].event)
+
+    if (rawLogs[i].event.indexOf('Debug') > -1) {
+      console.log(rawLogs[i].args.value.toString())
+    }
+  }
+}


### PR DESCRIPTION
Hopefully the second to last pull request related to staking. Adds a discount structure, where the governing body of the protocol can define a number of tokens to stake that will grant stakeholders a full discount on the protocol's fees. Also adding a lot of test coverage.

The potentially last PR here is related to the suggested annualized inflation rate on perceived stake values. i.e., if a stake is held for a year it would receive a 10% bonus in perceived weight, thereby granting it additional discounts on the protocol.