### PR TITLE
Changing providerId and providerMetadataId to generic data

### DIFF
--- a/contracts/CodexRecordAccess.sol
+++ b/contracts/CodexRecordAccess.sol
@@ -17,8 +17,7 @@ contract CodexRecordAccess is CodexRecordCore {
     bytes32 _nameHash,
     bytes32 _descriptionHash,
     bytes32[] _fileHashes,
-    string _providerId, // TODO: convert to bytes32
-    string _providerMetadataId // TODO: convert to bytes32
+    bytes _data
   )
     public
     whenNotPaused
@@ -29,9 +28,7 @@ contract CodexRecordAccess is CodexRecordCore {
       _nameHash,
       _descriptionHash,
       _fileHashes,
-      _providerId,
-      _providerMetadataId
-    );
+      _data);
   }
 
   /**
@@ -46,7 +43,10 @@ contract CodexRecordAccess is CodexRecordCore {
     whenNotPaused
     canPayFees(transferFee)
   {
-    return super.transferFrom(_from, _to, _tokenId);
+    return super.transferFrom(
+      _from,
+      _to,
+      _tokenId);
   }
 
   /**
@@ -61,7 +61,10 @@ contract CodexRecordAccess is CodexRecordCore {
     whenNotPaused
     canPayFees(transferFee)
   {
-    return super.safeTransferFrom(_from, _to, _tokenId);
+    return super.safeTransferFrom(
+      _from,
+      _to,
+      _tokenId);
   }
 
   /**
@@ -93,8 +96,7 @@ contract CodexRecordAccess is CodexRecordCore {
     bytes32 _newNameHash,
     bytes32 _newDescriptionHash,
     bytes32[] _newFileHashes,
-    string _providerId, // TODO: convert to bytes32?
-    string _providerMetadataId // TODO: convert to bytes32?
+    bytes _data
   )
     public
     whenNotPaused
@@ -105,8 +107,6 @@ contract CodexRecordAccess is CodexRecordCore {
       _newNameHash,
       _newDescriptionHash,
       _newFileHashes,
-      _providerId,
-      _providerMetadataId
-    );
+      _data);
   }
 }

--- a/contracts/CodexRecordCore.sol
+++ b/contracts/CodexRecordCore.sol
@@ -14,9 +14,9 @@ contract CodexRecordCore is CodexRecordFees {
    * @dev This event is emitted when a new token is minted and allows providers
    *  to discern which Minted events came from transactions they submitted vs
    *  transactions submitted by other platforms, as well as providing information
-   *  about what metadata record the newly minted token should be associated with
+   *  about what metadata record the newly minted token should be associated with.
    */
-  event Minted(uint256 _tokenId, string _providerId, string _providerMetadataId);
+  event Minted(uint256 _tokenId, bytes _data);
 
   /**
    * @dev Sets the global tokenURIPrefix for use when returning token metadata.
@@ -32,18 +32,14 @@ contract CodexRecordCore is CodexRecordFees {
    * @param _to address The address the token will get transferred to after minting
    * @param _nameHash bytes32 The sha3 hash of the name
    * @param _descriptionHash bytes32 The sha3 hash of the description
-   * @param _providerId string An ID that identifies which provider is
-   *  minting this token
-   * @param _providerMetadataId string An arbitrary provider-defined ID that
-   *  identifies the metadata record stored by the provider
+   * @param _data (optional) bytes Additional data that will be emitted with the Minted event
    */
   function mint(
     address _to,
     bytes32 _nameHash,
     bytes32 _descriptionHash,
     bytes32[] _fileHashes,
-    string _providerId, // @TODO: convert to bytes32
-    string _providerMetadataId  // @TODO: convert to bytes32
+    bytes _data
   )
     public
   {
@@ -52,19 +48,13 @@ contract CodexRecordCore is CodexRecordFees {
     internalMint(_to, newTokenId);
 
     // Add metadata to the newly created token
-    //
-    // @TODO: evaluate gas costs here, it may be more efficient to push each
-    //  individual file onto the existing fileHashes array for this index
-    //  instead of replacing the array altogether
     tokenData[newTokenId] = CodexRecordData({
       nameHash: _nameHash,
       descriptionHash: _descriptionHash,
       fileHashes: _fileHashes
     });
 
-    if (bytes(_providerId).length != 0 && bytes(_providerMetadataId).length != 0) {
-      emit Minted(newTokenId, _providerId, _providerMetadataId);
-    }
+    emit Minted(newTokenId, _data);
   }
 
   function internalMint(address _to, uint256 _tokenId) internal {

--- a/contracts/CodexRecordMetadata.sol
+++ b/contracts/CodexRecordMetadata.sol
@@ -50,7 +50,7 @@ contract CodexRecordMetadata is ERC721Token {
     onlyOwnerOf(_tokenId)
   {
     // nameHash is only overridden if it's not a blank string, since name is a
-    //  required value
+    //  required value. Emptiness is determined if the first element is the null-byte
     if (_newNameHash[0] != 0x0) {
       tokenData[_tokenId].nameHash = _newNameHash;
     }

--- a/scripts/mintTokens.js
+++ b/scripts/mintTokens.js
@@ -17,6 +17,11 @@ const ganachePrivateKeys = [
   'ae6ae8e5ccbfb04590405997ee2d52d2b330726137b875053c36d94e974d162f',
 ]
 
+const providerDataDelimeter = '::'
+const encodeProviderData = (providerData) => {
+  return `0x${Buffer.from(providerData.join(providerDataDelimeter)).toString('hex')}`
+}
+
 // Not perfect, but good enough for testing purposes
 const getTokenName = (tokenIndex) => {
   let prefix
@@ -115,8 +120,7 @@ const mintTokens = async (contract, authTokens, imageRecords) => {
           web3.sha3(result.name),
           web3.sha3(result.description),
           [result.mainImage.hash], // instead of downloading the file, reading it as binary data, and hashing that - we'll just use the hash created by the API since they should produce the same hash anyway
-          '1',
-          result.id,
+          encodeProviderData(['1', result.id]),
         )
 
       })

--- a/test/behaviors/CodexRecord.behavior.js
+++ b/test/behaviors/CodexRecord.behavior.js
@@ -1,4 +1,5 @@
 import assertRevert from '../helpers/assertRevert'
+import convertDataToBytes from '../helpers/convertDataToBytes'
 import modifyMetadataHashesUnbound from '../helpers/modifyMetadataHashes'
 
 const { BigNumber } = web3
@@ -8,16 +9,19 @@ require('chai')
   .use(require('chai-bignumber')(BigNumber))
   .should()
 
-export default function shouldBehaveLikeCodexRecord(accounts, metadata) {
+export default function shouldBehaveLikeCodexRecord(accounts, inputs) {
   const creator = accounts[0]
   const unauthorized = accounts[9]
   const firstTokenId = 0
 
   const {
     hashedMetadata,
-    providerId,
-    providerMetadataId,
-  } = metadata
+    data,
+  } = inputs
+
+  const dataAsBytes = convertDataToBytes(data)
+
+  console.log(dataAsBytes)
 
   let modifyMetadataHashes // initialized per-test in beforeEach below
 
@@ -28,8 +32,7 @@ export default function shouldBehaveLikeCodexRecord(accounts, metadata) {
         hashedMetadata.name,
         hashedMetadata.description,
         hashedMetadata.files,
-        providerId,
-        providerMetadataId
+        dataAsBytes,
       )
 
       const numTokens = await this.token.totalSupply()
@@ -72,8 +75,7 @@ export default function shouldBehaveLikeCodexRecord(accounts, metadata) {
               newNameHash,
               newDescriptionHash,
               newFileHashes,
-              providerId,
-              providerMetadataId,
+              dataAsBytes,
               { from: unauthorized },
             ),
           )
@@ -88,8 +90,8 @@ export default function shouldBehaveLikeCodexRecord(accounts, metadata) {
             newDescriptionHash: hashedMetadata.description,
             newFileHashes: [],
 
-            providerId,
-            providerMetadataId,
+            rawData: data,
+            dataAsBytes,
 
             expectedFileHashes: hashedMetadata.files,
           })
@@ -101,8 +103,8 @@ export default function shouldBehaveLikeCodexRecord(accounts, metadata) {
             newDescriptionHash,
             newFileHashes: [],
 
-            providerId,
-            providerMetadataId,
+            rawData: data,
+            dataAsBytes,
 
             expectedNameHash: hashedMetadata.name,
             expectedDescriptionHash: newDescriptionHash,
@@ -116,8 +118,8 @@ export default function shouldBehaveLikeCodexRecord(accounts, metadata) {
             newDescriptionHash: '',
             newFileHashes: hashedMetadata.files,
 
-            providerId,
-            providerMetadataId,
+            rawData: data,
+            dataAsBytes,
 
             expectedDescriptionHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
           })
@@ -129,8 +131,8 @@ export default function shouldBehaveLikeCodexRecord(accounts, metadata) {
             newDescriptionHash: hashedMetadata.description,
             newFileHashes,
 
-            providerId,
-            providerMetadataId,
+            rawData: data,
+            dataAsBytes,
 
             expectedNameHash: hashedMetadata.name,
           })
@@ -141,17 +143,16 @@ export default function shouldBehaveLikeCodexRecord(accounts, metadata) {
             newNameHash,
             newDescriptionHash,
             newFileHashes,
-
-            providerId,
-            providerMetadataId,
+            dataAsBytes,
           })
         })
 
-        it('should update all hashes when no providerId & providerMetadataId are provided', async function () {
+        it('should update all hashes when empty data is provided', async function () {
           await modifyMetadataHashes({
             newNameHash,
             newDescriptionHash,
             newFileHashes,
+            dataAsBytes: '0x',
           })
         })
       })

--- a/test/behaviors/CodexRecord.behavior.js
+++ b/test/behaviors/CodexRecord.behavior.js
@@ -20,9 +20,6 @@ export default function shouldBehaveLikeCodexRecord(accounts, inputs) {
   } = inputs
 
   const dataAsBytes = convertDataToBytes(data)
-
-  console.log(dataAsBytes)
-
   let modifyMetadataHashes // initialized per-test in beforeEach below
 
   describe('like a CodexRecord', function () {

--- a/test/behaviors/CodexRecordFees.behavior.js
+++ b/test/behaviors/CodexRecordFees.behavior.js
@@ -1,4 +1,5 @@
 import assertRevert from '../helpers/assertRevert'
+import convertDataToBytes from '../helpers/convertDataToBytes'
 import getCoreRegistryFunctions from '../helpers/getCoreRegistryFunctions'
 
 const { BigNumber } = web3
@@ -11,7 +12,7 @@ require('chai')
   .use(require('chai-bignumber')(BigNumber))
   .should()
 
-export default function shouldBehaveLikeCodexRecordWithFees(accounts, metadata) {
+export default function shouldBehaveLikeCodexRecordWithFees(accounts, inputs) {
   const creator = accounts[0]
   const otherUser = accounts[1]
   const communityFund = accounts[8]
@@ -24,10 +25,18 @@ export default function shouldBehaveLikeCodexRecordWithFees(accounts, metadata) 
     modification: web3.toWei(1, 'ether'),
   }
 
+  const {
+    hashedMetadata,
+    data,
+  } = inputs
+
+  const dataAsBytes = convertDataToBytes(data)
+
   const payableFunctions = getCoreRegistryFunctions(
     accounts,
     firstTokenId,
-    metadata
+    hashedMetadata,
+    dataAsBytes,
   )
 
   describe('like a CodexRecord with fees', function () {
@@ -37,11 +46,10 @@ export default function shouldBehaveLikeCodexRecordWithFees(accounts, metadata) 
       // pre-minting a token for use in some of the transfer tests
       await this.token.mint(
         creator,
-        metadata.hashedMetadata.name,
-        metadata.hashedMetadata.description,
-        metadata.hashedMetadata.files,
-        metadata.providerId,
-        metadata.providerMetadataId,
+        hashedMetadata.name,
+        hashedMetadata.description,
+        hashedMetadata.files,
+        dataAsBytes,
       )
 
       // Set contract fees, sent to the community fund

--- a/test/core/CodexRecord.test.js
+++ b/test/core/CodexRecord.test.js
@@ -11,14 +11,16 @@ require('chai')
   .should()
 
 contract('CodexRecord', function (accounts) {
-  const metadata = {
+  const inputs = {
     hashedMetadata: {
       name: web3.sha3('First token'),
       description: web3.sha3('This is the first token'),
       files: [web3.sha3('file data')],
     },
-    providerId: '1',
-    providerMetadataId: '10',
+    data: {
+      providerId: '1',
+      providerMetadataId: '10',
+    },
   }
 
   beforeEach(async function () {
@@ -29,8 +31,8 @@ contract('CodexRecord', function (accounts) {
   shouldBehaveLikeERC165()
 
   // Base behavior, no fees
-  shouldBehaveLikeCodexRecord(accounts, metadata)
+  shouldBehaveLikeCodexRecord(accounts, inputs)
 
   // Extended functionality & base behavior with fees enabled
-  shouldBehaveLikeCodexRecordWithFees(accounts, metadata)
+  shouldBehaveLikeCodexRecordWithFees(accounts, inputs)
 })

--- a/test/core/CodexRecordAccess.test.js
+++ b/test/core/CodexRecordAccess.test.js
@@ -1,4 +1,5 @@
 import assertRevert from '../helpers/assertRevert'
+import convertDataToBytes from '../helpers/convertDataToBytes'
 import getCoreRegistryFunctions from '../helpers/getCoreRegistryFunctions'
 
 const { BigNumber } = web3
@@ -21,13 +22,18 @@ contract('CodexRecordAccess', async function (accounts) {
     files: [web3.sha3('file data')],
   }
 
+  const data = {
+    providerId,
+    providerMetadataId,
+  }
+
+  const dataAsBytes = convertDataToBytes(data)
+
   const pausableFunctions = getCoreRegistryFunctions(
     accounts,
-    firstTokenId, {
-      hashedMetadata,
-      providerId,
-      providerMetadataId,
-    }
+    firstTokenId,
+    hashedMetadata,
+    dataAsBytes,
   )
 
   describe('when the contract is paused', function () {

--- a/test/core/CodexRecordAccess.test.js
+++ b/test/core/CodexRecordAccess.test.js
@@ -48,8 +48,7 @@ contract('CodexRecordAccess', async function (accounts) {
         hashedMetadata.name,
         hashedMetadata.description,
         hashedMetadata.files,
-        providerId,
-        providerMetadataId,
+        dataAsBytes,
       )
 
       await token.pause()

--- a/test/core/CodexRecordProxy.extended.test.js
+++ b/test/core/CodexRecordProxy.extended.test.js
@@ -1,3 +1,4 @@
+import convertDataToBytes from '../helpers/convertDataToBytes'
 import shouldBehaveLikeERC721BasicToken from '../behaviors/ERC721BasicToken.behavior'
 
 const { BigNumber } = web3
@@ -22,14 +23,20 @@ contract('CodexRecordProxy', async function (accounts) {
     })
 
     describe('should behave', function () {
+      const data = {
+        providerId: '1',
+        providerMetadataId: '10',
+      }
+
+      const dataAsBytes = convertDataToBytes(data)
+
       async function mintToken(tokenToMint, tokenCreator) {
         await tokenToMint.mint(
           tokenCreator,
           web3.sha3('name'),
           web3.sha3('description'),
           [web3.sha3('file data')],
-          '1',
-          '10'
+          dataAsBytes,
         )
       }
 

--- a/test/core/CodexRecordProxy.test.js
+++ b/test/core/CodexRecordProxy.test.js
@@ -214,14 +214,16 @@ contract('CodexRecordProxy', async function (accounts) {
   })
 
   describe('proxying CodexRecord', function () {
-    const metadata = {
+    const inputs = {
       hashedMetadata: {
         name: web3.sha3('First token'),
         description: web3.sha3('This is the first token'),
         files: [web3.sha3('file data')],
       },
-      providerId: '1',
-      providerMetadataId: '10',
+      data: {
+        providerId: '1',
+        providerMetadataId: '10',
+      },
     }
 
     beforeEach(async function () {
@@ -233,8 +235,8 @@ contract('CodexRecordProxy', async function (accounts) {
     })
 
     describe('should behave', function () {
-      shouldBehaveLikeCodexRecord(accounts, metadata)
-      shouldBehaveLikeCodexRecordWithFees(accounts, metadata)
+      shouldBehaveLikeCodexRecord(accounts, inputs)
+      shouldBehaveLikeCodexRecordWithFees(accounts, inputs)
     })
   })
 })

--- a/test/helpers/convertDataToBytes.js
+++ b/test/helpers/convertDataToBytes.js
@@ -1,11 +1,12 @@
 const convertDataToBytes = (data) => {
+  const numColons = 2
   let concatenatedString = ''
 
   Object.values(data).forEach((value) => {
     concatenatedString += `${value}::`
   })
 
-  const buffer = Buffer.from(concatenatedString.substring(0, concatenatedString.length - 3))
+  const buffer = Buffer.from(concatenatedString.substring(0, concatenatedString.length - numColons))
   return `0x${buffer.toString('hex')}`
 }
 

--- a/test/helpers/convertDataToBytes.js
+++ b/test/helpers/convertDataToBytes.js
@@ -1,8 +1,8 @@
 const convertDataToBytes = (data) => {
   let concatenatedString = ''
 
-  Object.keys(data).forEach((key) => {
-    concatenatedString += `${data[key]}:::`
+  Object.values(data).forEach((value) => {
+    concatenatedString += `${value}::`
   })
 
   const buffer = Buffer.from(concatenatedString.substring(0, concatenatedString.length - 3))

--- a/test/helpers/convertDataToBytes.js
+++ b/test/helpers/convertDataToBytes.js
@@ -1,12 +1,5 @@
 const convertDataToBytes = (data) => {
-  const numColons = 2
-  let concatenatedString = ''
-
-  Object.values(data).forEach((value) => {
-    concatenatedString += `${value}::`
-  })
-
-  const buffer = Buffer.from(concatenatedString.substring(0, concatenatedString.length - numColons))
+  const buffer = Buffer.from(Object.values(data).join('::'))
   return `0x${buffer.toString('hex')}`
 }
 

--- a/test/helpers/convertDataToBytes.js
+++ b/test/helpers/convertDataToBytes.js
@@ -1,0 +1,12 @@
+const convertDataToBytes = (data) => {
+  let concatenatedString = ''
+
+  Object.keys(data).forEach((key) => {
+    concatenatedString += `${data[key]}:::`
+  })
+
+  const buffer = Buffer.from(concatenatedString.substring(0, concatenatedString.length - 3))
+  return `0x${buffer.toString('hex')}`
+}
+
+export default convertDataToBytes

--- a/test/helpers/getCoreRegistryFunctions.js
+++ b/test/helpers/getCoreRegistryFunctions.js
@@ -1,12 +1,6 @@
-const getCoreRegistryFunctions = (accounts, firstTokenId, metadata) => {
+const getCoreRegistryFunctions = (accounts, firstTokenId, hashedMetadata, dataAsBytes) => {
   const creator = accounts[0]
   const another = accounts[1]
-
-  const {
-    hashedMetadata,
-    providerId,
-    providerMetadataId,
-  } = metadata
 
   return [{
     name: 'mint',
@@ -16,8 +10,7 @@ const getCoreRegistryFunctions = (accounts, firstTokenId, metadata) => {
       hashedMetadata.name,
       hashedMetadata.description,
       hashedMetadata.files,
-      providerId,
-      providerMetadataId,
+      dataAsBytes,
     ],
   }, {
     name: 'transferFrom',
@@ -52,8 +45,7 @@ const getCoreRegistryFunctions = (accounts, firstTokenId, metadata) => {
       hashedMetadata.name,
       hashedMetadata.description,
       hashedMetadata.files,
-      providerId,
-      providerMetadataId,
+      dataAsBytes,
     ],
   }]
 }

--- a/test/helpers/modifyMetadataHashes.js
+++ b/test/helpers/modifyMetadataHashes.js
@@ -49,11 +49,11 @@ export default async function modifyMetadataHashes({
 
   if (rawData && dataAsBytes !== '0x') {
     const buffer = Buffer.from(data.substring(2), 'hex')
-    const tokenizedData = buffer.toString('utf8').split(':::')
+    const tokenizedData = buffer.toString('utf8').split('::')
     let tokenIndex = 0
 
-    Object.keys(rawData).forEach((key) => {
-      rawData[key].should.be.equal(tokenizedData[tokenIndex])
+    Object.values(rawData).forEach((value) => {
+      value.should.be.equal(tokenizedData[tokenIndex])
       tokenIndex += 1
     })
   }


### PR DESCRIPTION
These are breaking changes. I won't merge this until we are ready on the FE/BE side.

Summary of changes:
- [x] Change `providerId` and `providerMetadataId` to `data`, an argument of type `bytes`
- [x] Always emit a `Minted` event, even if `data` is empty
- [x] Always emit a `Modified` event, even if `data` is empty
- [x] Update test cases to reflect the latest changes